### PR TITLE
Feature/refactor press awards display

### DIFF
--- a/src/awsS3/helperFunctions.ts
+++ b/src/awsS3/helperFunctions.ts
@@ -1,7 +1,8 @@
 import { postData } from '../utils/apiCalls';
 import CryptoJS from 'crypto-js';
-const yourModuleName = require('crypto-js');
 
+
+//********** Helpers **********//
 export const fileToData = (file: any) => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -24,66 +25,6 @@ export const fileCheckSum = async (file: any) => {
   const checksum = md5.toString(CryptoJS.enc.Base64)
   return checksum
 }
-
-
-export const postToAWS = async (image: any) => {
-  //first I want to run my fileToData which returns a Promise
-  // const file = await fileToData(image)
-
-  // const sum = await fileCheckSum(image)
-  // console.log('filmPoster', image)
-
-  // //when that cowboy resolves, I want to use it's guts to make the options object that will be POSTed to the backend to acquire the presignedURL. This will also be asychronous
-
-  // const body = {
-  //   file: {
-  //     filename: image.name,
-  //     byte_size: image.size,
-  //     checksum: sum,
-  //     content_type: image.type,
-  //     metadata: {
-  //       'message': 'film poster test'
-  //     }
-  //   }
-  // }
-
-  // const presignedFileParams = await postData('https://epk-be.herokuapp.com/api/v1/presigned_url', body)
-
-  const presignedFileParams: any = getPresignedUrl(image)
-
-  //once we have our presignedURL response from above 
-  // const s3PutOptions = {
-  //   method: 'PUT',
-  //   headers: presignedFileParams.direct_upload.headers,
-  //   body: image,
-  // }
-
-  // let awsRes = await fetch(presignedFileParams.direct_upload.url, s3PutOptions)
-  // if (awsRes.status !== 200) return awsRes
-
-  const resFromAWS = putToAWS(presignedFileParams, image)
-
-
-  let usersPostOptions = {
-    method: 'POST',
-    headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      // film_epk_id: filmEPK.id,
-      blob_signed_id: presignedFileParams.blob_signed_id,
-    })
-  }
-  let res = await fetch('https://epk-be.herokuapp.com/api/v1/movie_posters', usersPostOptions)
-  if (res.status !== 200) return res
-
-  let data = await res.json()
-  console.log(data)
-  // We need to pass this value to state 
-  // setPoster(data.movie_poster_url);
-}
-
 
 //********** STEP 1 **********//
 

--- a/src/components/AwardsPress/AwardPressDisplay.tsx
+++ b/src/components/AwardsPress/AwardPressDisplay.tsx
@@ -11,7 +11,8 @@ interface APProps {
 }
 
 const AwardPressDisplay = ({ awards, presses }: APProps) => {
-  let awardPressArray: any;
+  let combinedAwardPress: any;
+
 
   if (presses !== undefined || awards !== undefined) {
     let pressCards: any;
@@ -38,22 +39,45 @@ const AwardPressDisplay = ({ awards, presses }: APProps) => {
         );
       });
     }
-    awardPressArray = awardCards.reduce(
-      (awardPress: any, item: any, i: number) => {
-        awardPress.push(item, pressCards[i]);
-        return awardPress;
-      },
-      []
-    );
-    // console.log(awardPressArray);
+
+    const orderAwardsPress = () => {
+      if (awardCards.length >= pressCards.length) {
+        return awardCards.reduce(
+          (combined: any, award: any, i: number) => {
+            combined.push(award, pressCards[i]);
+            return combined;
+          },
+          []
+        )
+      } else {
+        return pressCards.reduce(
+          (combined: any, press: any, i: number) => {
+            combined.push(press, awardCards[i]);
+            return combined;
+          },
+          []
+        )
+      }
+    }
+
+    combinedAwardPress = orderAwardsPress();
   }
 
   return (
     <section>
       {/* <h3 className="awards-press-title">Articles and Awards</h3> */}
-      <div className="award-press-display">{awardPressArray}</div>
+      <div className="award-press-display">{combinedAwardPress}</div>
     </section>
   );
 };
 
 export default AwardPressDisplay;
+
+
+// awardPressArray = awardCards.reduce(
+//   (awardPress: any, item: any, i: number) => {
+//     awardPress.push(item, pressCards[i]);
+//     return awardPress;
+//   },
+//   []
+// );

--- a/src/components/AwardsPress/AwardPressDisplay.tsx
+++ b/src/components/AwardsPress/AwardPressDisplay.tsx
@@ -11,14 +11,14 @@ interface APProps {
 }
 
 const AwardPressDisplay = ({ awards, presses }: APProps) => {
-  let combinedAwardPress: any;
+  let combinedAwardPress: JSX.Element[] | undefined;
 
 
   if (presses !== undefined || awards !== undefined) {
-    let pressCards: any;
-    let awardCards: any;
+    let pressCards: JSX.Element[];
+    let awardCards: JSX.Element[];
     if (awards !== undefined) {
-      awardCards = awards.map((award, i) => {
+      awardCards = awards.map((award) => {
         return (
           <AwardCard
             key={award.id}
@@ -29,7 +29,7 @@ const AwardPressDisplay = ({ awards, presses }: APProps) => {
       });
     }
     if (presses !== undefined) {
-      pressCards = presses.map((press, i) => {
+      pressCards = presses.map((press) => {
         return (
           <PressCard
             key={press.id}
@@ -40,10 +40,11 @@ const AwardPressDisplay = ({ awards, presses }: APProps) => {
       });
     }
 
+    //this function will currently alternate placement of press and award starting with whichever is longer.
     const orderAwardsPress = () => {
       if (awardCards.length >= pressCards.length) {
         return awardCards.reduce(
-          (combined: any, award: any, i: number) => {
+          (combined: JSX.Element[], award: JSX.Element, i: number) => {
             combined.push(award, pressCards[i]);
             return combined;
           },
@@ -51,7 +52,7 @@ const AwardPressDisplay = ({ awards, presses }: APProps) => {
         )
       } else {
         return pressCards.reduce(
-          (combined: any, press: any, i: number) => {
+          (combined: JSX.Element[], press: JSX.Element, i: number) => {
             combined.push(press, awardCards[i]);
             return combined;
           },
@@ -72,12 +73,3 @@ const AwardPressDisplay = ({ awards, presses }: APProps) => {
 };
 
 export default AwardPressDisplay;
-
-
-// awardPressArray = awardCards.reduce(
-//   (awardPress: any, item: any, i: number) => {
-//     awardPress.push(item, pressCards[i]);
-//     return awardPress;
-//   },
-//   []
-// );

--- a/src/components/pages/EditPage/EditPage.tsx
+++ b/src/components/pages/EditPage/EditPage.tsx
@@ -65,15 +65,7 @@ const EditPage = ({ epk_id, id }: any) => {
               isPressPage={false}
             />
 
-            {included.length > 0 ||
-              (film.id && (
-                <AwardsPressContainer
-                  addFilmInfo={addFilmInfo}
-                  epk_id={epk_id}
-                  included={included}
-                />
-              ))}
-            {included.length > 0 && film.id && (
+            {film.id && (
               <AwardsPressContainer
                 addFilmInfo={addFilmInfo}
                 epk_id={epk_id}


### PR DESCRIPTION
# Description
I have refactored the AwardPressDisplay to fix the bug that causing press or only render when there were as many awards. It now generates the display with alternating award and press cards. If there are more press cards, the display will start with press instead of award, which affects the color pattern (i.e. it goes smoke, orange, smoke instead of orange, smoke, orange). 

I also was able to add types for the variables that were typed as any in the PressAwardsDisplay

- [x] what did you do?
- [x] why did you do it?

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
- [x] Use console.log()
- [x]] Dev tools / react dev tools
- [x] View in local host

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
